### PR TITLE
Optimization: Combine string cleanup into single pass in NewFs()

### DIFF
--- a/backend/zus/zus.go
+++ b/backend/zus/zus.go
@@ -29,22 +29,22 @@ import (
 var (
 	// batcher default options
 	defaultBatcherOptions = batcher.Options{
-		MaxBatchSize: 50,
-		DefaultTimeoutSync: 500 * time.Millisecond,
-		DefaultTimeoutAsync: 5 * time.Second,
+		MaxBatchSize:          50,
+		DefaultTimeoutSync:    500 * time.Millisecond,
+		DefaultTimeoutAsync:   5 * time.Second,
 		DefaultBatchSizeAsync: 100,
 	}
 )
 
 type Options struct {
-	AllocationID string `config:"allocation_id"`
-	ConfigDir    string `config:"config_dir"`
-	Encrypt      bool   `config:"encrypt"`
-	WorkDir      string `config:"work_dir"`
-	SdkLogLevel  int    `config:"sdk_log_level"`
-	BatchMode    string `config:"batch_mode"`
+	AllocationID string        `config:"allocation_id"`
+	ConfigDir    string        `config:"config_dir"`
+	Encrypt      bool          `config:"encrypt"`
+	WorkDir      string        `config:"work_dir"`
+	SdkLogLevel  int           `config:"sdk_log_level"`
+	BatchMode    string        `config:"batch_mode"`
 	BatchTimeout time.Duration `config:"batch_timeout"`
-	BatchSize    int    `config:"batch_size"`
+	BatchSize    int           `config:"batch_size"`
 }
 
 type Fs struct {
@@ -54,7 +54,7 @@ type Fs struct {
 	opts     Options      // parsed options
 	features *fs.Features // optional features
 	alloc    *sdk.Allocation
-	batcher *batcher.Batcher[sdk.OperationRequest, struct{}] // batcher for operations
+	batcher  *batcher.Batcher[sdk.OperationRequest, struct{}] // batcher for operations
 }
 
 func init() {
@@ -154,8 +154,12 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 			return nil, err
 		}
 
-		allocationID := strings.ReplaceAll(string(allocBytes), " ", "")
-		allocationID = strings.ReplaceAll(allocationID, "\n", "")
+		allocationID := strings.Map(func(r rune) rune {
+			if r == ' ' || r == '\n' || r == '\r' || r == '\t' {
+				return -1
+			}
+			return r
+		}, string(allocBytes))
 
 		if len(allocationID) != 64 {
 			return nil, fmt.Errorf("allocation id has length %d, should be 64", len(allocationID))


### PR DESCRIPTION
This change replaces two chained `strings.ReplaceAll` calls with a single `strings.Map` iteration to clean allocation IDs in one pass on line 157. 
```
//old code
allocationID := strings.ReplaceAll(string(allocBytes), " ", "")
allocationID = strings.ReplaceAll(allocationID, "\n", "")
```
It removes redundant iterations and reduces intermediate allocations. Tested CLI build successfully (`rclone_zus.exe --help`) with dummy env vars.
```
// new one
allocationID := strings.Map(func(r rune) rune {
	if r == ' ' || r == '\n' || r == '\r' || r == '\t' {
		return -1
	}
	return r
}, string(allocBytes))
```
Test CLI build successfully (`rclone_zus.exe --help`) with dummy env vars
