### PR TITLE
zus.go: Error log, nil check and clean up allocation ID by removing whitespace characters

### DIFF
--- a/backend/zus/zus.go
+++ b/backend/zus/zus.go
@@ -93,6 +93,16 @@ func init() {
 	})
 }
 
+// removes newlines, tab spaces and extra unecessary
+func removeWhitespace(r rune) rune {
+	switch r {
+	case ' ', '\n', '\r', '\t':
+		return -1
+	default:
+		return r
+	}
+}
+
 // NewFs constructs an Fs from the path
 func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, error) {
 
@@ -155,12 +165,8 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 			return nil, err
 		}
 
-		allocationID := strings.Map(func(r rune) rune {
-			if r == ' ' || r == '\n' || r == '\r' || r == '\t' {
-				return -1
-			}
-			return r
-		}, string(allocBytes))
+		// removes extra spaces and new lines from the allocation.txt if present
+		allocationID := strings.Map(removeWhitespace, string(allocBytes))
 
 		if len(allocationID) != 64 {
 			return nil, fmt.Errorf("allocation id has length %d, should be 64", len(allocationID))


### PR DESCRIPTION
1. Added Error check and logs on put() and remove() functions.
2. Added nil check for the file system initialization.
3. Extracted common whitespace-stripping logic into a reusable `removeWhitespace` function, 
which removes spaces, tabs, carriage returns, and newlines from input.

Updated the allocation ID parsing in `NewFs` to use this helper, ensuring the value 
read from `allocation.txt` is clean.

This improves readability and reusability of the whitespace cleaning logic.

Example:
- Raw file content: "\n 795f63...\t\r\n"
- After cleaning:   "795f63..."
