### PR TITLE
improve: add more descriptive error message in NewFs

### DIFF
--- a/backend/zus/zus.go
+++ b/backend/zus/zus.go
@@ -169,21 +169,21 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		allocationID := strings.Map(removeWhitespace, string(allocBytes))
 
 		if len(allocationID) != 64 {
-			return nil, fmt.Errorf("allocation id has length %d, should be 64", len(allocationID))
+			return nil, fmt.Errorf("invalid allocation ID: expect 64 characters but got %d. Please check allocation.txt in %s for extra spaces, newlines, or incorrect values.", len(allocationID))
 		}
 		f.opts.AllocationID = allocationID
 	}
 
 	cfg, err := conf.LoadConfigFile(filepath.Join(f.opts.ConfigDir, "config.yaml"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to load config.yaml from %s: %w", f.opts.ConfigDir, err)
 	}
 	var walletInfo string
 	walletFile := filepath.Join(f.opts.ConfigDir, "wallet.json")
 
 	walletBytes, err := os.ReadFile(walletFile)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read wallet.json from %s: %w", walletFile, err)
 	}
 	walletInfo = string(walletBytes)
 	err = client.InitSDK("{}", cfg.BlockWorker, cfg.ChainID, cfg.SignatureScheme, 0, true, cfg.MinSubmit, cfg.MinConfirmation, cfg.ConfirmationChainLength, cfg.SharderConsensous)


### PR DESCRIPTION
Added more descriptive error messages in `NewFs()` to improve user guidance when:
- Allocation ID is invalid
- "Config" or "Wallet" files fail to load
- Provides clearer instructions and file paths to help users debug setup issues.

This will help users quickly locate and fix configuration problems instead of receiving non-descriptive errors