### PR TITLE
feat(makefile): add static build support for Windows target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ build-linux:
 build-windows:
 	GOOS=windows GOARCH=amd64 CGO_ENABLED=1 \
 	CC=x86_64-w64-mingw32-gcc \
-	CGO_CFLAGS="-static -O2" \
-	CGO_LDFLAGS="-static" \
-	go build -x -v -tags bn256 -o rclone.exe rclone.go
+	CGO_CFLAGS="-O2 -static" \
+	CGO_LDFLAGS="-static -lstdc++ -lm -lwinpthread" \
+	go build -x -v -tags bn256 -ldflags="-extldflags '-static'" -o rclone.exe rclone.go
 
 # for Intel Mac binary
 build-mac-amd:


### PR DESCRIPTION
Updated the `build-windows` Makefile target to enable fully static Windows builds using MinGW-w64.

Changes include:
- Use `CGO_CFLAGS` and `CGO_LDFLAGS` with `-static` and relevant libraries (`-lstdc++ -lm -lwinpthread`)
- Added `-ldflags="-extldflags '-static'"` to fully static link the binary

This ensures the resulting `rclone.exe` does not depend on runtime DLLs like `libstdc++-6.dll` or `libwinpthread-1.dll`, improving portability on Windows systems.
