### PR TITLE
Windows static build change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,13 @@ build-linux:
 build-windows:
 	GOOS=windows GOARCH=amd64 CGO_ENABLED=1 \
 	CC=x86_64-w64-mingw32-gcc \
-	CGO_CFLAGS="-O2 -static" \
-	CGO_LDFLAGS="-static -lstdc++ -lm -lwinpthread" \
-	go build -x -v -tags bn256 -ldflags="-extldflags '-static'" -o rclone.exe rclone.go
+	CXX=x86_64-w64-mingw32-g++ \
+	CGO_LDFLAGS="-static -static-libgcc -static-libstdc++ -lstdc++ -lwinpthread -lgcc_eh -lgcc -lmsvcrt -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 -lws2_32 -liphlpapi -lpsapi -lversion -lwinmm -lwininet -lurlmon -loleacc -lcomctl32" \
+	go build -a -v -tags bn256 \
+		-ldflags="-extldflags=-static -s -w" \
+		-o rclone.exe rclone.go
+
+
 
 # for Intel Mac binary
 build-mac-amd:


### PR DESCRIPTION
# Changes
The current windows build command is dynamic and requires external dependencies to be installed (such as Mingw64 compiler),

The command changes include the necessary dependencies to make it static

# Steps for Testing
This must be tested on windows which does not have gcc and rclone installed, please run the following commands in order
- `gcc` (Expected result is this should throw an error)
- `rclone` (Expected result is this should throw an error)
- Download [this](https://drive.google.com/file/d/1SxwmnRIv62JkPzoHzKrh20jb_ioH_7Nj/view?usp=sharing) file
- Run `././rclone_build_test_windows.exe`, the expected result is that it should give the flags and commands that are available.

# Testing Results

Since we are getting the flags on a windows that does not have gcc and rclone installed, this is the expected result on running the executable
<img width="2992" height="1452" alt="image" src="https://github.com/user-attachments/assets/8300653d-9ed0-448e-88be-564b773f22e5" />
