### PR TITLE
Improved readme and fixed GH action build for windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,7 +146,7 @@ jobs:
         with:
           go-version: '1.22'
 
-      - run: make build-windows-native
+      - run: make build-windows
 
       - name: Create ~/.zcn and add wallet.json and config.yaml
         shell: powershell

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 [<img src="https://rclone.org/img/logo_on_light__horizontal_color.svg" width="50%" alt="rclone logo">](https://rclone.org/#gh-light-mode-only)
 [<img src="https://rclone.org/img/logo_on_dark__horizontal_color.svg" width="50%" alt="rclone logo">](https://rclone.org/#gh-dark-mode-only)
 
@@ -79,14 +80,6 @@ This backend implementation allows developers, DevOps teams, and cloud users to:
 
 **For reliable performance:**
 - Use Züs blobbers usually provide better stability and performance
-
-### Configuration Tips
-
-**Finding rclone.conf:**
-To locate your rclone configuration file, simply use:
-```bash
-./rclone config file
-```
 
 ## Configuration
 
@@ -214,8 +207,9 @@ e) Edit this remote
 d) Delete this remote
 y/e/d> y
 ```
-
 Make sure your **rclone.conf** file is created.
+**Finding rclone.conf:**
+- To locate your rclone configuration file (`rclone.conf`) via command line, use the command `rclone config file`
 - For Windows, check %APPDATA%\rclone\rclone.conf. If you downloaded the rclone.exe, you can place the rclone.conf in the same directory as the .exe.
 - For macOS/Linux, check ~/.config/rclone/rclone.conf
 
@@ -267,7 +261,7 @@ Example: create new direcotry in the root (This example shows new directory name
 **Local to Züs Examples:**
 ```bash
 # Windows example - copying from local Windows path to Züs remote
-rclone copy "C:\Users\Murica\OneDrive\Desktop\New folder" myZus:/testDirectory
+rclone copy "C:\Users\<username>\OneDrive\Desktop\New folder" myZus:/testDirectory
 
 # Linux/macOS example - copying from local Unix path to Züs remote  
 rclone copy /home/user/documents myZus:/backup
@@ -304,7 +298,7 @@ rclone copy myZus:/sourcefilesDir/ myZus:/destinationDir/
 **Local to Züs Examples:**
 ```bash
 # Windows example - moving from local Windows path to Züs remote
-rclone move "C:\Users\ABC\Desktop\New folder" myZus:/testDirectory
+rclone move "C:\Users\<username>\Desktop\New folder" myZus:/testDirectory
 
 # Linux/macOS example - moving from local Unix path to Züs remote
 rclone move /home/user/documents myZus:/backup

--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ This backend implementation allows developers, DevOps teams, and cloud users to:
 
 - Fast Sync: Avoid redundant uploads with batch commit
 
+### Allocation Performance
+
+**For reliable performance:**
+- Use Züs blobbers usually provide better stability and performance
+
+### Configuration Tips
+
+**Finding rclone.conf:**
+To locate your rclone configuration file, simply use:
+```bash
+./rclone config file
+```
+
 ## Configuration
 
 **Prerequisites**
@@ -247,20 +260,76 @@ Example: create new direcotry in the root (This example shows new directory name
 
 **Copy** from source to destination `(Local to Remote, Remote to Remote, Remote to Local)`
 
-    rclone copy <remote name>:<source path> <remote name>:<destination path>    
+    `rclone copy <source_remote>:<source_path> <target_remote>:<target_path>` 
     
-Example
+- **Note**: Copy/move/sync commands only work within the same remote (same allocation). You cannot copy/move/sync across two different remotes (different allocations). 
 
-    rclone copy myZus:/sourcefilesDir/ myZus:/destinationDir/
+**Local to Züs Examples:**
+```bash
+# Windows example - copying from local Windows path to Züs remote
+rclone copy "C:\Users\Murica\OneDrive\Desktop\New folder" myZus:/testDirectory
+
+# Linux/macOS example - copying from local Unix path to Züs remote  
+rclone copy /home/user/documents myZus:/backup
+```
+
+**Züs to Local Examples:**
+```bash
+# Copying from Züs remote to local directory
+rclone copy myZus:/documents /home/user/downloads
+```
+
+**Cross-Cloud Backup Examples (Google Drive ↔ Züs):**
+```bash
+# Google Drive to Züs backup (source: gdrive, target: myZus)
+rclone copy gdrive:important-files myZus:/backup
+
+# Züs to Google Drive backup (source: myZus, target: gdrive)
+rclone copy myZus:/documents gdrive:zus-backup
+```
+
+**Same Remote Operations (within same allocation):**
+```bash
+# Copying within the same Züs remote (source: myZus, target: myZus)
+rclone copy myZus:/sourcefilesDir/ myZus:/destinationDir/
+```
 
 
 **Move** from source to destination `(Local to Remote, Remote to Remote, Remote to Local)`
 
-    rclone move <remote name>:<source path> <remote name>:<destination path>    
+    `rclone move <source_remote>:<source_path> <target_remote>:<target_path>` 
     
-Example
+- **Cross-Remote Limitation**: Same limitation as copy - only works within the same remote/allocation
 
-    rclone move myZus:/sourcefilesDir/ myZus:/destinationDir/
+**Local to Züs Examples:**
+```bash
+# Windows example - moving from local Windows path to Züs remote
+rclone move "C:\Users\ABC\Desktop\New folder" myZus:/testDirectory
+
+# Linux/macOS example - moving from local Unix path to Züs remote
+rclone move /home/user/documents myZus:/backup
+```
+
+**Züs to Local Examples:**
+```bash
+# Moving from Züs remote to local directory
+rclone move myZus:/documents /home/user/downloads
+```
+
+**Cross-Cloud Examples (Google Drive ↔ Züs):**
+```bash
+# Google Drive to Züs (source remote: gdrive, target remote: myZus)
+rclone move gdrive:important-files myZus:/backup
+
+# Züs to Google Drive (source remote: myZus, target remote: gdrive)
+rclone move myZus:/documents gdrive:zus-backup
+```
+
+**Same Remote Operations (within same allocation):**
+```bash
+# Moving within the same Züs remote (source remote: myZus, target remote: myZus)
+rclone move myZus:/sourcefilesDir/ myZus:/destinationDir/
+```
 
 Sync `/home/local/directory` to the remote path, deleting any
 excess files in the path.


### PR DESCRIPTION
# Fix Windows build target and enhance README documentation

## Changes Made

### Build Fix
- Fixed Windows build target in GitHub Actions workflow
- Changed `make build-windows-native` to `make build-windows`

### README Improvements
- Added comprehensive command examples with clear source/target context
- Added cross-cloud backup examples (Google Drive ↔ Züs)
- Clarified cross-remote limitations
- Added performance recommendations
- Added configuration tips for finding rclone.conf
- 
## Why the Build Fix was Needed
The Makefile contains `build-windows` target but the workflow was referencing to `build-windows-native` target, causing incorrect Windows builds.